### PR TITLE
Replace binstall with binstalk-downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -85,47 +114,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "binstall"
+name = "binstalk-downloader"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20971ec5a4c16bbda204e695ca1c8afa983295fab726dcc84306f338ee52f648"
 dependencies = [
- "async-trait",
+ "binstalk-types",
+ "binstall-tar",
  "bytes",
  "bzip2",
- "cargo_toml",
- "clap",
- "compact_str",
- "crates_io_api",
- "detect-targets",
  "digest",
  "flate2",
- "flock",
  "futures-util",
  "generic-array",
- "home",
- "itertools",
- "jobserver",
- "log",
- "miette",
- "normalize-path",
- "once_cell",
+ "httpdate",
  "reqwest",
  "scopeguard",
- "semver",
- "serde",
- "serde-tuple-vec-map",
- "serde_json",
- "strum",
- "strum_macros",
- "tar",
  "tempfile",
  "thiserror",
- "tinytemplate",
  "tokio",
- "toml_edit",
+ "tower",
+ "tracing",
+ "trust-dns-resolver",
  "url",
  "xz2",
  "zip",
  "zstd",
+]
+
+[[package]]
+name = "binstalk-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accefc541791716261b9627cd45329e2f51449fe1f97237156a27023b8bee789"
+dependencies = [
+ "compact_str",
+ "once_cell",
+ "semver",
+ "serde",
+ "strum",
+ "strum_macros",
+ "url",
+]
+
+[[package]]
+name = "binstall-tar"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01db907e07c37309ea816c183ffe548daaa66ef640a291408f232d6ca4089dbb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -144,6 +184,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,9 +218,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2"
@@ -218,56 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
-dependencies = [
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15f2ea93df33549dbe2e8eecd1ca55269d63ae0b3ba1f55db030817d1c2867f"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
- "clap_lex",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,26 +288,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "compact_str"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5857fc4f27cd0fa2cd7c4a4fa780c0da3d898ae27e66bf6a719343e219e9a559"
+checksum = "5138945395949e7dfba09646dc9e766b548ff48e23deb5246890e6b64ae9e1b9"
 dependencies = [
  "castaway",
  "itoa",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -325,23 +342,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smartstring",
-]
-
-[[package]]
-name = "crates_io_api"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f8072e3f4581325ee6c8e3c900099b303924a9c592ab4d23bb87ee5bdc6f7b"
-dependencies = [
- "chrono",
- "futures",
- "log",
- "reqwest",
- "serde",
- "serde_derive",
- "serde_json",
- "tokio",
- "url",
 ]
 
 [[package]]
@@ -415,19 +415,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
-name = "detect-targets"
-version = "0.1.0"
-dependencies = [
- "cfg-if",
- "guess_host_triple",
- "tokio",
-]
-
-[[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -451,35 +442,14 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -521,13 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flock"
-version = "0.1.0"
-dependencies = [
- "fs4",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,38 +498,11 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "fs4"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9813c3dc174931eff4bd78609debba56465b7c1da888576d21636b601a46790"
-dependencies = [
- "libc",
- "rustix",
- "winapi",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
 ]
 
 [[package]]
@@ -581,32 +517,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -615,23 +540,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -641,6 +565,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -683,18 +616,6 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "url",
-]
-
-[[package]]
-name = "guess_host_triple"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35a8ce923c7490629d84e12fa2f75e1733f1ec692a47c264f9b7fd632855afc"
-dependencies = [
- "errno",
- "libc",
- "log",
- "winapi",
 ]
 
 [[package]]
@@ -858,6 +779,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,12 +806,6 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "io-lifetimes"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "ipconfig"
@@ -905,15 +830,6 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
-
-[[package]]
-name = "itertools"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -991,12 +907,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -1141,29 +1051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-path"
-version = "0.1.0"
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl-probe"
@@ -1206,12 +1093,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "owo-colors"
@@ -1244,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "phf"
@@ -1264,6 +1145,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1322,30 +1223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1236,59 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b435e71d9bfa0d8889927231970c51fb89c58fa63bffcab117c9c7a41e5ef8f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "fxhash",
+ "quinn-proto",
+ "quinn-udp",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce546b9688f767a57530652488420d419a8b1f44a478b451c3d1ab6d992a55"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "rand",
+ "ring",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile 0.2.1",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07946277141531aea269befd949ed16b2c85a780ba1043244eda0969e538e54"
+dependencies = [
+ "futures-util",
+ "libc",
+ "quinn-proto",
+ "socket2",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "quote"
@@ -1469,10 +1399,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -1485,13 +1416,13 @@ dependencies = [
  "hyper-rustls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1546,20 +1477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustix"
-version = "0.35.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustls"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,6 +1486,27 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1593,6 +1531,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,37 +1557,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.13"
+name = "security-framework"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde-tuple-vec-map"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04d0ebe0de77d7d445bb729a895dcb0a288854b267ca85f030ce51cdc578c82"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1770,12 +1732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,7 +1788,7 @@ dependencies = [
 name = "survey-index"
 version = "0.1.0"
 dependencies = [
- "binstall",
+ "binstalk-downloader",
  "cargo_toml",
  "crates-index",
  "miette",
@@ -1860,17 +1816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,15 +1827,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1916,18 +1852,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1941,16 +1877,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1970,9 +1896,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1980,7 +1906,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2059,16 +1984,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.14.4"
+name = "tower"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "combine",
- "indexmap",
- "itertools",
- "serde",
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -2078,11 +2014,12 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2090,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2101,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2153,47 +2090,60 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
+ "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna",
+ "h2",
+ "http",
+ "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "log",
+ "quinn",
  "rand",
+ "ring",
+ "rustls",
+ "rustls-pemfile 1.0.1",
  "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
+ "tokio-rustls",
+ "tracing",
  "url",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
  "cfg-if",
  "futures-util",
  "ipconfig",
  "lazy_static",
- "log",
  "lru-cache",
  "parking_lot",
  "resolv-conf",
+ "rustls",
  "smallvec",
  "thiserror",
  "tokio",
+ "tokio-rustls",
+ "tracing",
  "trust-dns-proto",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2252,13 +2202,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna",
- "matches",
+ "idna 0.3.0",
  "percent-encoding",
  "serde",
 ]
@@ -2415,15 +2364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
 dependencies = [
  "byteorder",
  "bzip2",
@@ -2524,18 +2464,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2543,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]
-binstall = { version = "0.1.0", path = "../cargo-binstall/crates/lib" }
+binstalk-downloader = { version = "0.1.0", features = ["zlib-ng", "trust-dns", "zstd-thin"] }
 crates-index = "0.18.9"
 semver = "1.0.13"
 tracing = "0.1.36"

--- a/src/bin/fetch-crates.rs
+++ b/src/bin/fetch-crates.rs
@@ -6,15 +6,16 @@
 #[cfg(not(tokio_unstable))]
 fn main() {}
 
-use std::{env, fmt::Display};
+use std::{env, fmt::Display, num::NonZeroU64, time::Duration};
 
-use binstall::{helpers::download::Download, manifests::cargo_toml_binstall::PkgFmt};
+use binstalk_downloader::{
+	download::{Download, PkgFmt},
+	remote::Client,
+};
 use crates_index::Index;
 use miette::{IntoDiagnostic, Result};
 use rayon::prelude::ParallelIterator;
-use reqwest::Client;
 use semver::Version;
-use sha2::Sha256;
 #[cfg(tokio_unstable)]
 use tokio::task::JoinSet;
 use tracing::{error, info};
@@ -26,111 +27,114 @@ const CHUNK_SIZE: usize = 512;
 #[cfg(tokio_unstable)]
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(env::var("RUST_LOG").unwrap_or("info".into()))
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .init();
+	tracing_subscriber::fmt()
+		.with_env_filter(env::var("RUST_LOG").unwrap_or("info".into()))
+		.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+		.init();
 
-    info!("Gathering all crates we need to fetch");
-    let all_latests = read_index()?;
-    let total = all_latests.len();
-    info!(%total, "that's a lot of crates");
+	info!("Gathering all crates we need to fetch");
+	let all_latests = read_index()?;
+	let total = all_latests.len();
+	info!(%total, "that's a lot of crates");
 
-    let client = Client::builder()
-        .http2_prior_knowledge()
-        .http2_adaptive_window(true)
-        .build()
-        .into_diagnostic()?;
+	let client = Client::new(
+		concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+		None,
+		Duration::from_millis(5),
+		NonZeroU64::new(1).unwrap(),
+	)
+	.into_diagnostic()?;
 
-    for (n, chunk) in all_latests.chunks(CHUNK_SIZE).enumerate() {
-        info!("Processing {n}th of {}", all_latests.len() / CHUNK_SIZE + 1);
-        get_a_bunch(client.clone(), n, total, chunk).await?;
-    }
+	for (n, chunk) in all_latests.chunks(CHUNK_SIZE).enumerate() {
+		info!("Processing {n}th of {}", all_latests.len() / CHUNK_SIZE + 1);
+		get_a_bunch(client.clone(), n, total, chunk).await?;
+	}
 
-    Ok(())
+	Ok(())
 }
 
 #[cfg(tokio_unstable)]
 async fn get_a_bunch(client: Client, n: usize, total: usize, chunk: &[IndexCrate]) -> Result<()> {
-    let mut set = JoinSet::new();
+	let mut set = JoinSet::new();
 
-    for (i, crate_version) in chunk.into_iter().enumerate() {
-        set.spawn(
-            crate_version
-                .clone()
-                .download(client.clone(), n * CHUNK_SIZE + i, total),
-        );
-    }
+	for (i, crate_version) in chunk.into_iter().enumerate() {
+		set.spawn(
+			crate_version
+				.clone()
+				.download(client.clone(), n * CHUNK_SIZE + i, total),
+		);
+	}
 
-    while let Some(res) = set.join_next().await {
-        if let Err(err) = res {
-            error!("{err}");
-        }
-    }
+	while let Some(res) = set.join_next().await {
+		if let Err(err) = res {
+			error!("{err}");
+		}
+	}
 
-    Ok(())
+	Ok(())
 }
 
 #[derive(Clone, Debug)]
 struct IndexCrate {
-    pub name: String,
-    pub version: Version,
-    pub url: Url,
-    pub checksum: [u8; 32],
+	pub name: String,
+	pub version: Version,
+	pub url: Url,
+	pub checksum: [u8; 32],
 }
 
 impl IndexCrate {
-    #[tracing::instrument(level = "debug")]
-    async fn download(self, client: Client, i: usize, total: usize) -> Result<()> {
-        info!(target=%self, "downloading {i}/{total}");
-        Download::<Sha256>::new_with_checksum(client, self.url.clone(), self.checksum[..].to_vec())
-            .and_extract(PkgFmt::Tgz, "./crates")
-            .await?;
-        info!(target=%self, "downloaded {i}/{total}");
+	#[tracing::instrument(level = "debug")]
+	async fn download(self, client: Client, i: usize, total: usize) -> Result<()> {
+		info!(target=%self, "downloading {i}/{total}");
+		Download::new(client, self.url.clone())
+			.and_extract(PkgFmt::Tgz, "./crates", None)
+			.await
+			.into_diagnostic()?;
+		info!(target=%self, "downloaded {i}/{total}");
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 impl Display for IndexCrate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            name,
-            version,
-            url,
-            checksum,
-        } = self;
-        let ch = u64::from_le_bytes(checksum[0..8].try_into().unwrap());
-        let ec = u64::from_le_bytes(checksum[8..16].try_into().unwrap());
-        let ks = u64::from_le_bytes(checksum[16..24].try_into().unwrap());
-        let um = u64::from_le_bytes(checksum[24..32].try_into().unwrap());
-        write!(f, "{name}@{version}: {url} [{ch:x} {ec:x} {ks:x} {um:x}]")
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		let Self {
+			name,
+			version,
+			url,
+			checksum,
+		} = self;
+		let ch = u64::from_le_bytes(checksum[0..8].try_into().unwrap());
+		let ec = u64::from_le_bytes(checksum[8..16].try_into().unwrap());
+		let ks = u64::from_le_bytes(checksum[16..24].try_into().unwrap());
+		let um = u64::from_le_bytes(checksum[24..32].try_into().unwrap());
+		write!(f, "{name}@{version}: {url} [{ch:x} {ec:x} {ks:x} {um:x}]")
+	}
 }
 
 #[tracing::instrument]
 fn read_index() -> Result<Vec<IndexCrate>> {
-    let index = Index::new_cargo_default().into_diagnostic()?;
-    let all_latests: Vec<_> = index
-        .crates_parallel()
-        .filter_map(|c| {
-            c.ok().and_then(|c| {
-                c.highest_normal_version().map(|v| {
-                    let name = v.name().into();
-                    let version = v.version().parse().unwrap();
-                    let url = Url::parse(&format!(
-                        "https://static.crates.io/crates/{name}/{name}-{version}.crate"
-                    ))
-                    .unwrap();
-                    IndexCrate {
-                        name,
-                        version,
-                        url,
-                        checksum: *v.checksum(),
-                    }
-                })
-            })
-        })
-        .collect();
-    Ok(all_latests)
+	let index = Index::new_cargo_default().into_diagnostic()?;
+	let all_latests: Vec<_> = index
+		.crates_parallel()
+		.filter_map(|c| {
+			c.ok().and_then(|c| {
+				c.highest_normal_version().map(|v| {
+					let name = v.name().into();
+					let version = v.version().parse().unwrap();
+					let url = Url::parse(&format!(
+						"https://static.crates.io/crates/{name}/{name}-{version}.crate"
+					))
+					.unwrap();
+					IndexCrate {
+						name,
+						version,
+						url,
+						checksum: *v.checksum(),
+					}
+				})
+			})
+		})
+		.collect();
+	Ok(all_latests)
 }

--- a/src/bin/fetch-crates.rs
+++ b/src/bin/fetch-crates.rs
@@ -28,7 +28,7 @@ const CHUNK_SIZE: usize = 512;
 #[tokio::main]
 async fn main() -> Result<()> {
 	tracing_subscriber::fmt()
-		.with_env_filter(env::var("RUST_LOG").unwrap_or("info".into()))
+		.with_env_filter(env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
 		.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
 		.init();
 
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
 async fn get_a_bunch(client: Client, n: usize, total: usize, chunk: &[IndexCrate]) -> Result<()> {
 	let mut set = JoinSet::new();
 
-	for (i, crate_version) in chunk.into_iter().enumerate() {
+	for (i, crate_version) in chunk.iter().enumerate() {
 		set.spawn(
 			crate_version
 				.clone()

--- a/src/bin/load-crates.rs
+++ b/src/bin/load-crates.rs
@@ -21,9 +21,9 @@ use std::{env, fs::read_dir, path::PathBuf, sync::Arc};
 
 use cargo_toml::Manifest;
 use miette::{IntoDiagnostic, Result};
-use tokio_postgres::{Client};
 #[cfg(tokio_unstable)]
 use tokio::task::JoinSet;
+use tokio_postgres::Client;
 use tracing::{error, info};
 use tracing_subscriber::fmt::format::FmtSpan;
 
@@ -32,85 +32,102 @@ const CHUNK_SIZE: usize = 512;
 #[cfg(tokio_unstable)]
 #[tokio::main]
 async fn main() -> Result<()> {
-    use std::time::Duration;
+	use std::time::Duration;
 
-    use tokio::time::sleep;
+	use tokio::time::sleep;
 
-    tracing_subscriber::fmt()
-        .with_env_filter(env::var("RUST_LOG").unwrap_or("info".into()))
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .init();
+	tracing_subscriber::fmt()
+		.with_env_filter(env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+		.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+		.init();
 
-    let crates = read_dir("./crates/")
-        .into_diagnostic()?
-        .map(|res| res.map(|e| e.path()))
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()?;
-    let total = crates.len();
-    info!(%total, "listed some crates");
+	let crates = read_dir("./crates/")
+		.into_diagnostic()?
+		.map(|res| res.map(|e| e.path()))
+		.collect::<Result<Vec<_>, _>>()
+		.into_diagnostic()?;
+	let total = crates.len();
+	info!(%total, "listed some crates");
 
-    let (client, conn) = tokio_postgres::connect(
-        &env::var("DATABASE_URL").expect("DATABASE_URL not set"),
-        tokio_postgres::tls::NoTls,
-    )
-    .await
-    .into_diagnostic()?;
-    info!("connected to postgres");
+	let (client, conn) = tokio_postgres::connect(
+		&env::var("DATABASE_URL").expect("DATABASE_URL not set"),
+		tokio_postgres::tls::NoTls,
+	)
+	.await
+	.into_diagnostic()?;
+	info!("connected to postgres");
 
-    let conntask = tokio::spawn(conn);
-    let client = Arc::new(client);
+	let conntask = tokio::spawn(conn);
+	let client = Arc::new(client);
 
-    for (n, chunk) in crates.chunks(CHUNK_SIZE).enumerate() {
-        info!("Processing {n}th of {}", crates.len() / CHUNK_SIZE + 1);
-        load_a_bunch(client.clone(), n, total, chunk).await?;
-    }
+	for (n, chunk) in crates.chunks(CHUNK_SIZE).enumerate() {
+		info!("Processing {n}th of {}", crates.len() / CHUNK_SIZE + 1);
+		load_a_bunch(client.clone(), n, total, chunk).await?;
+	}
 
-    sleep(Duration::from_secs(1)).await;
-    drop(client);
+	sleep(Duration::from_secs(1)).await;
+	drop(client);
 
-    info!("waiting for postgres to finish");
-    conntask.await.into_diagnostic()?.into_diagnostic()?;
+	info!("waiting for postgres to finish");
+	conntask.await.into_diagnostic()?.into_diagnostic()?;
 
-    info!("done");
-    Ok(())
+	info!("done");
+	Ok(())
 }
 
 #[cfg(tokio_unstable)]
-async fn load_a_bunch(client: Arc<Client>, n: usize, total: usize, chunk: &[PathBuf]) -> Result<()> {
-    let mut set = JoinSet::new();
+async fn load_a_bunch(
+	client: Arc<Client>,
+	n: usize,
+	total: usize,
+	chunk: &[PathBuf],
+) -> Result<()> {
+	let mut set = JoinSet::new();
 
-    for (i, crate_path) in chunk.into_iter().enumerate() {
-        set.spawn(parse_and_load_crate(crate_path.clone(), client.clone(), n * CHUNK_SIZE + i, total));
-    }
+	for (i, crate_path) in chunk.iter().enumerate() {
+		set.spawn(parse_and_load_crate(
+			crate_path.clone(),
+			client.clone(),
+			n * CHUNK_SIZE + i,
+			total,
+		));
+	}
 
-    while let Some(res) = set.join_next().await {
-        let res = res.into_diagnostic()?;
-        if let Err(err) = res {
-            error!("{err:?}");
-        }
-    }
+	while let Some(res) = set.join_next().await {
+		let res = res.into_diagnostic()?;
+		if let Err(err) = res {
+			error!("{err:?}");
+		}
+	}
 
-    Ok(())
+	Ok(())
 }
 
 #[tracing::instrument(level = "debug")]
-async fn parse_and_load_crate(path: PathBuf, client: Arc<Client>, i: usize, total: usize) -> Result<()> {
-    info!("parsing {i}/{total}");
-    let toml = Manifest::from_path(path.join("Cargo.toml")).into_diagnostic()?;
-    let package = if let Some(ref pkg) = toml.package {
-        pkg
-    } else {
-        miette::bail!("Not a package crate: {path}");
-    };
+async fn parse_and_load_crate(
+	path: PathBuf,
+	client: Arc<Client>,
+	i: usize,
+	total: usize,
+) -> Result<()> {
+	info!("parsing {i}/{total}");
+	let toml = Manifest::from_path(path.join("Cargo.toml")).into_diagnostic()?;
+	let package = if let Some(ref pkg) = toml.package {
+		pkg
+	} else {
+		miette::bail!("Not a package crate: {path}");
+	};
 
-    info!("loading {i}/{total}");
-    let json = serde_json::to_value(&toml).into_diagnostic()?;
-    client.execute("INSERT INTO crates (name, version, manifest) VALUES ($1, $2, $3);", &[
-        &package.name,
-        &package.version,
-        &json,
-    ]).await.into_diagnostic()?;
+	info!("loading {i}/{total}");
+	let json = serde_json::to_value(&toml).into_diagnostic()?;
+	client
+		.execute(
+			"INSERT INTO crates (name, version, manifest) VALUES ($1, $2, $3);",
+			&[&package.name, &package.version, &json],
+		)
+		.await
+		.into_diagnostic()?;
 
-    info!("loaded {i}/{total}");
-    Ok(())
+	info!("loaded {i}/{total}");
+	Ok(())
 }


### PR DESCRIPTION
* Use binstalk-downloader instead of binstall (non-existent), which
   - Disable checksum verification (binstalk-downloader does not support that).
   - Use `binstalk_downloader::remote::Client::new` instead of `ClientBuilder`,
      which means that we cannot specify option "http2_prior_knowledge" or
      "http2_adaptive_window". 
* Fix clippy warnings

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>